### PR TITLE
Trim leading and trailing spaces from service tags

### DIFF
--- a/registry/consul/routecmd.go
+++ b/registry/consul/routecmd.go
@@ -26,6 +26,9 @@ type routecmd struct {
 func (r routecmd) build() []string {
 	var svctags, routetags []string
 	for _, t := range r.svc.ServiceTags {
+
+		t = strings.TrimSpace(t)
+
 		if strings.HasPrefix(t, r.prefix) {
 			routetags = append(routetags, t)
 		} else {

--- a/registry/consul/routecmd_test.go
+++ b/registry/consul/routecmd_test.go
@@ -29,6 +29,53 @@ func TestRouteCmd(t *testing.T) {
 			},
 		},
 		{
+			name: "http single tag with a space",
+			r: routecmd{
+				prefix: "p-",
+				svc: &api.CatalogService{
+					ServiceName:    "svc-1",
+					ServiceAddress: "1.1.1.1",
+					ServicePort:    2222,
+					ServiceTags:    []string{` p-foo/bar`},
+				},
+			},
+			cfg: []string{
+				`route add svc-1 foo/bar http://1.1.1.1:2222/`,
+			},
+		},
+		{
+			name: "http multiple tags",
+			r: routecmd{
+				prefix: "p-",
+				svc: &api.CatalogService{
+					ServiceName:    "svc-1",
+					ServiceAddress: "1.1.1.1",
+					ServicePort:    2222,
+					ServiceTags:    []string{`p-foo/bar`, `p-test/foo`},
+				},
+			},
+			cfg: []string{
+				`route add svc-1 foo/bar http://1.1.1.1:2222/`,
+				`route add svc-1 test/foo http://1.1.1.1:2222/`,
+			},
+		},
+		{
+			name: "http multiple routes with space prefix route",
+			r: routecmd{
+				prefix: "p-",
+				svc: &api.CatalogService{
+					ServiceName:    "svc-1",
+					ServiceAddress: "1.1.1.1",
+					ServicePort:    2222,
+					ServiceTags:    []string{`p-foo/bar`, `  p-test/foo`},
+				},
+			},
+			cfg: []string{
+				`route add svc-1 foo/bar http://1.1.1.1:2222/`,
+				`route add svc-1 test/foo http://1.1.1.1:2222/`,
+			},
+		},
+		{
 			name: "tcp",
 			r: routecmd{
 				prefix: "p-",


### PR DESCRIPTION
This update modifies the 'routecmd' function to trim leading and trailing spaces from service tags. Corresponding tests have been added to verify correct functionality when space-prefixed or suffixed tags are encountered. These changes ensure consistency in how tags are processed and compared.